### PR TITLE
Improve client parallelism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ script:
             py.test tests/ \
                     --cov spalloc \
                     --cov tests \
-                    --durations=10
+                    --durations=10 \
+                    --timeout=120
         # Code quality check
         - flake8
 after_success:

--- a/spalloc/protocol_client.py
+++ b/spalloc/protocol_client.py
@@ -3,9 +3,6 @@
 import socket
 import json
 import time
-
-from functools import partial
-
 from collections import deque
 
 
@@ -262,15 +259,57 @@ class ProtocolClient(object):
         else:
             return None
 
-    def __getattr__(self, name):
-        """:py:meth:`.call` commands by calling 'methods' of this object.
+    # The bindings of the Spalloc protocol methods themselves
 
-        For example, the following lines are equivilent::
+    def version(self, timeout=None):
+        return self.call("version", timeout=timeout)
 
-            c.call("foo", 1, bar=2, on_return=f)
-            c.foo(1, bar=2, on_return=f)
-        """
-        if name.startswith("_"):
-            raise AttributeError(name)
-        else:
-            return partial(self.call, name)
+    def create_job(self, *args, **kwargs):
+        return self.call("create_job", *args, **kwargs)
+
+    def job_keepalive(self, job_id, timeout=None):
+        return self.call("job_keepalive", job_id, timeout=timeout)
+
+    def get_job_state(self, job_id, timeout=None):
+        return self.call("get_job_state", job_id, timeout=timeout)
+
+    def get_job_machine_info(self, job_id, timeout=None):
+        return self.call("get_job_machine_info", job_id, timeout=timeout)
+
+    def power_on_job_boards(self, job_id, timeout=None):
+        return self.call("power_on_job_boards", job_id, timeout=timeout)
+
+    def power_off_job_boards(self, job_id, timeout=None):
+        return self.call("power_off_job_boards", job_id, timeout=timeout)
+
+    def destroy_job(self, job_id, reason=None, timeout=None):
+        return self.call("destroy_job", job_id, reason, timeout=timeout)
+
+    def notify_job(self, job_id=None, timeout=None):
+        return self.call("notify_job", job_id, timeout=timeout)
+
+    def no_notify_job(self, job_id=None, timeout=None):
+        return self.call("no_notify_job", job_id, timeout=timeout)
+
+    def notify_machine(self, machine_name=None, timeout=None):
+        return self.call("notify_machine", machine_name, timeout=timeout)
+
+    def no_notify_machine(self, machine_name=None, timeout=None):
+        return self.call("no_notify_machine", machine_name, timeout=timeout)
+
+    def list_jobs(self, timeout=None):
+        return self.call("list_jobs", timeout=timeout)
+
+    def list_machines(self, timeout=None):
+        return self.call("list_machines", timeout=timeout)
+
+    def get_board_position(self, machine_name, x, y, z, timeout=None):
+        return self.call("get_board_position", machine_name, x, y, z,
+                         timeout=timeout)
+
+    def get_board_at_position(self, machine_name, x, y, z, timeout=None):
+        return self.call("get_board_at_position", machine_name, x, y, z,
+                         timeout=timeout)
+
+    def where_is(self, **kwargs):
+        return self.call("where_is", **kwargs)

--- a/spalloc/protocol_client.py
+++ b/spalloc/protocol_client.py
@@ -90,7 +90,7 @@ class ProtocolClient(object):
             self._local.buffer = b""
             self._local.sock = sock
             sock.settimeout(timeout)
-            if not self._do_connect(sock):
+            if not self._do_connect(sock):  # pragma: no cover
                 self._close(key)
                 return self._get_connection(timeout)
 
@@ -98,17 +98,17 @@ class ProtocolClient(object):
         return sock
 
     def _do_connect(self, sock):
+        success = False
         try:
             sock.connect((self._hostname, self._port))
-            return True
+            success = True
         except OSError as e:
             if e.errno != errno.EISCONN:
                 raise
-            return False
         except socket.error as e:
             if e[0] != errno.EISCONN:
                 raise
-            return False
+        return success
 
     def _has_open_socket(self):
         if "sock" not in self._local.__dict__:
@@ -144,7 +144,7 @@ class ProtocolClient(object):
             key = current_thread()
         with self._socks_lock:
             sock = self._socks.get(key, None)
-            if sock is None:
+            if sock is None:  # pragma: no cover
                 return
             del self._socks[key]
         if key == current_thread():
@@ -319,53 +319,58 @@ class ProtocolClient(object):
 
     # The bindings of the Spalloc protocol methods themselves
 
-    def version(self, timeout=None):
+    def version(self, timeout=None):  # pragma: no cover
         return self.call("version", timeout=timeout)
 
-    def create_job(self, *args, **kwargs):
+    def create_job(self, *args, **kwargs):  # pragma: no cover
         return self.call("create_job", *args, **kwargs)
 
-    def job_keepalive(self, job_id, timeout=None):
+    def job_keepalive(self, job_id, timeout=None):  # pragma: no cover
         return self.call("job_keepalive", job_id, timeout=timeout)
 
-    def get_job_state(self, job_id, timeout=None):
+    def get_job_state(self, job_id, timeout=None):  # pragma: no cover
         return self.call("get_job_state", job_id, timeout=timeout)
 
-    def get_job_machine_info(self, job_id, timeout=None):
+    def get_job_machine_info(self, job_id, timeout=None):  # pragma: no cover
         return self.call("get_job_machine_info", job_id, timeout=timeout)
 
-    def power_on_job_boards(self, job_id, timeout=None):
+    def power_on_job_boards(self, job_id, timeout=None):  # pragma: no cover
         return self.call("power_on_job_boards", job_id, timeout=timeout)
 
-    def power_off_job_boards(self, job_id, timeout=None):
+    def power_off_job_boards(self, job_id, timeout=None):  # pragma: no cover
         return self.call("power_off_job_boards", job_id, timeout=timeout)
 
-    def destroy_job(self, job_id, reason=None, timeout=None):
+    def destroy_job(self, job_id, reason=None,
+                    timeout=None):  # pragma: no cover
         return self.call("destroy_job", job_id, reason, timeout=timeout)
 
-    def notify_job(self, job_id=None, timeout=None):
+    def notify_job(self, job_id=None, timeout=None):  # pragma: no cover
         return self.call("notify_job", job_id, timeout=timeout)
 
-    def no_notify_job(self, job_id=None, timeout=None):
+    def no_notify_job(self, job_id=None, timeout=None):  # pragma: no cover
         return self.call("no_notify_job", job_id, timeout=timeout)
 
-    def notify_machine(self, machine_name=None, timeout=None):
+    def notify_machine(self, machine_name=None,
+                       timeout=None):  # pragma: no cover
         return self.call("notify_machine", machine_name, timeout=timeout)
 
-    def no_notify_machine(self, machine_name=None, timeout=None):
+    def no_notify_machine(self, machine_name=None,
+                          timeout=None):  # pragma: no cover
         return self.call("no_notify_machine", machine_name, timeout=timeout)
 
-    def list_jobs(self, timeout=None):
+    def list_jobs(self, timeout=None):  # pragma: no cover
         return self.call("list_jobs", timeout=timeout)
 
-    def list_machines(self, timeout=None):
+    def list_machines(self, timeout=None):  # pragma: no cover
         return self.call("list_machines", timeout=timeout)
 
-    def get_board_position(self, machine_name, x, y, z, timeout=None):
+    def get_board_position(self, machine_name, x, y, z,
+                           timeout=None):  # pragma: no cover
         return self.call("get_board_position", machine_name, x, y, z,
                          timeout=timeout)
 
-    def get_board_at_position(self, machine_name, x, y, z, timeout=None):
+    def get_board_at_position(self, machine_name, x, y, z,
+                              timeout=None):  # pragma: no cover
         return self.call("get_board_at_position", machine_name, x, y, z,
                          timeout=timeout)
 

--- a/spalloc/scripts/machine.py
+++ b/spalloc/scripts/machine.py
@@ -279,13 +279,12 @@ def main(argv=None):
             # Wait for changes (if required)
             if retval != 0 or not args.watch:
                 return retval
-            else:
-                try:
-                    client.wait_for_notification()
-                    print("")
-                except KeyboardInterrupt:
-                    print("")
-                    return 0
+            try:
+                client.wait_for_notification()
+                print("")
+            except KeyboardInterrupt:
+                print("")
+                return 0
 
     except (IOError, OSError, ProtocolTimeoutError) as e:
         sys.stderr.write("Error communicating with server: {}\n".format(e))

--- a/spalloc/scripts/ps.py
+++ b/spalloc/scripts/ps.py
@@ -179,24 +179,22 @@ def main(argv=None):
             if args.watch:
                 sys.stdout.write(t.clear_screen())
 
-            print(render_job_list(
-                t, jobs, args.machine, args.owner))
+            print(render_job_list(t, jobs, args.machine, args.owner))
 
             # Exit or wait for changes, if requested
             if not args.watch:
                 return 0
-            else:
-                # Wait for state change
-                try:
-                    client.wait_for_notification()
-                except KeyboardInterrupt:
-                    # Gracefully exit
-                    print("")
-                    return 0
-
-                # Print a newline to separate old table from the new table when
-                # it gets printed if ANSI screen clearing is not possible.
+            # Wait for state change
+            try:
+                client.wait_for_notification()
+            except KeyboardInterrupt:
+                # Gracefully exit
                 print("")
+                return 0
+
+            # Print a newline to separate old table from the new table when
+            # it gets printed if ANSI screen clearing is not possible.
+            print("")
 
     except (IOError, OSError, ProtocolTimeoutError) as e:
         sys.stderr.write("Error communicating with server: {}\n".format(e))

--- a/spalloc/scripts/where_is.py
+++ b/spalloc/scripts/where_is.py
@@ -165,21 +165,21 @@ def main(argv=None):
         if location is None:
             sys.stderr.write("No boards at the specified location.\n")
             return 4
-        else:
-            out = OrderedDict()
-            out["Machine"] = location["machine"]
-            out["Physical location"] = "Cabinet {}, Frame {}, Board {}".format(
-                *location["physical"])
-            out["Board coordinate"] = tuple(location["logical"])
-            out["Machine chip coordinates"] = tuple(location["chip"])
-            if show_board_chip:
-                out["Coordinates within board"] = tuple(location["board_chip"])
-            out["Job using board"] = location["job_id"]
-            if location["job_id"]:
-                out["Coordinates within job"] = tuple(location["job_chip"])
 
-            print(render_definitions(out))
-            return 0
+        out = OrderedDict()
+        out["Machine"] = location["machine"]
+        out["Physical location"] = "Cabinet {}, Frame {}, Board {}".format(
+            *location["physical"])
+        out["Board coordinate"] = tuple(location["logical"])
+        out["Machine chip coordinates"] = tuple(location["chip"])
+        if show_board_chip:
+            out["Coordinates within board"] = tuple(location["board_chip"])
+        out["Job using board"] = location["job_id"]
+        if location["job_id"]:
+            out["Coordinates within job"] = tuple(location["job_chip"])
+
+        print(render_definitions(out))
+        return 0
 
     except (IOError, OSError, ProtocolTimeoutError) as e:
         sys.stderr.write("Error communicating with server: {}\n".format(e))

--- a/tests/test_protocol_client.py
+++ b/tests/test_protocol_client.py
@@ -1,7 +1,5 @@
 import pytest
-
 from mock import Mock
-
 import socket
 import threading
 import time
@@ -17,7 +15,7 @@ logging.basicConfig(level=logging.DEBUG)
 class TestConnect(object):
 
     @pytest.mark.timeout(1.0)
-    def test_first_time(self, s, c, bg_accept):
+    def test_first_time(self, s, c, bg_accept):  # @UnusedVariable
         # If server already available, should just connect straight away
         c.connect()
         bg_accept.join()
@@ -56,23 +54,23 @@ class TestConnect(object):
 @pytest.mark.timeout(1.0)
 def test_close(c, s, bg_accept):
     # If already connected, should be able to close
-    assert c._sock is None
+    assert not c._has_open_socket()
     c.connect()
-    assert c._sock is not None
+    assert c._has_open_socket()
     c.close()
-    assert c._sock is None
+    assert not c._has_open_socket()
     bg_accept.join()
     s.close()
 
     # Should be able to close again
     c.close()
-    assert c._sock is None
+    assert not c._has_open_socket()
 
     # And should be able to close a newly created connection
     c = ProtocolClient("localhost")
-    assert c._sock is None
+    assert not c._has_open_socket()
     c.close()
-    assert c._sock is None
+    assert not c._has_open_socket()
 
 
 @pytest.mark.timeout(1.0)
@@ -129,8 +127,10 @@ def test_send_json(c, s, bg_accept):
 
 @pytest.mark.timeout(1.0)
 def test_send_json_fails(c):
-    c._sock = Mock()
-    c._sock.send.side_effect = [1, socket.timeout()]
+    sock = Mock()
+    sock.send.side_effect = [1, socket.timeout()]
+    c._socks[threading.current_thread()] = sock
+    c._dead = False
 
     # If full amount is not sent, should fail
     with pytest.raises((IOError, OSError)):
@@ -209,9 +209,13 @@ def test_commands_as_methods(c, s, bg_accept):
     bg_accept.join()
 
     s.send({"return": "Woo"})
-    assert c.foo(1, bar=2) == "Woo"
-    assert s.recv() == {"command": "foo", "args": [1], "kwargs": {"bar": 2}}
+    assert c.where_is(1, bar=2) == "Woo"
+    assert s.recv() == {
+        "command": "where_is", "args": [1], "kwargs": {"bar": 2}}
 
-    # Should fail for _prefixed things to help quickly find internal bugs...
+    # Should fail for arbitrary internal method names
     with pytest.raises(AttributeError):
         c._bar()
+    # Should fail for arbitrary external method names
+    with pytest.raises(AttributeError):
+        c.bar()


### PR DESCRIPTION
Make the low level client open multiple connections on demand so that use of the client from several threads doesn't cause massive confusion. (See https://github.com/SpiNNakerManchester/spalloc/issues/7 for details.)