### PR TITLE
User host reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,15 @@ python:
         - 2.7
         - 3.4
         - 3.5
+cache: pip
+before_install:
+        - pip install --upgrade pip setuptools wheel
 install:
         - python setup.py develop
         - pip install -r requirements-test.txt
         - pip install python-coveralls
 script:
-        - >
-            py.test tests/ \
-                    --cov spalloc \
-                    --cov tests \
-                    --durations=10 \
-                    --timeout=120
+        - py.test tests/ --cov spalloc --cov tests --durations=10 --timeout=120
         # Code quality check
         - flake8
 after_success:
@@ -23,4 +21,4 @@ notifications:
         email: false
 
 matrix:
-    fast_finish: true
+        fast_finish: true

--- a/spalloc/scripts/job.py
+++ b/spalloc/scripts/job.py
@@ -118,6 +118,8 @@ def show_job_info(t, client, timeout, job_id):
             local_timestamp = utc_timestamp.astimezone(get_localzone())
             info["Start time"] = local_timestamp.strftime('%d/%m/%Y %H:%M:%S')
         info["Keepalive"] = job["keepalive"]
+        if "keepalivehost" in job and job["keepalivehost"] is not None:
+            info["Owner host"] = job["keepalivehost"]
 
         args = job["args"]
         kwargs = job["kwargs"]

--- a/spalloc/scripts/machine.py
+++ b/spalloc/scripts/machine.py
@@ -181,14 +181,17 @@ def show_machine(t, machines, jobs, machine_name, compact=False):
             (t.underscore_bright, "Key"),
             (t.underscore_bright, "Job ID"),
             (t.underscore_bright, "Num boards"),
-            (t.underscore_bright, "Owner"),
+            (t.underscore_bright, "Owner (Host)"),
         ]]
         for job in displayed_jobs:
+            owner = job["owner"]
+            if "keepalivehost" in job and job["keepalivehost"] is not None:
+                owner += " (%s)" % job["keepalivehost"]
             job_table.append([
                 (job["colour"], job["key"]),
                 job["job_id"],
                 len(job["boards"]),
-                job["owner"],
+                owner,
             ])
         print("")
         print(render_table(job_table))

--- a/spalloc/scripts/ps.py
+++ b/spalloc/scripts/ps.py
@@ -46,7 +46,7 @@ def render_job_list(t, jobs, args):
                   (t.underscore_bright, "Machine"),
                   (t.underscore_bright, "Created at"),
                   (t.underscore_bright, "Keepalive"),
-                  (t.underscore_bright, "Owner")))
+                  (t.underscore_bright, "Owner (Host)")))
 
     for job in jobs:
         # Filter jobs
@@ -87,6 +87,10 @@ def render_job_list(t, jobs, args):
         else:
             machine_name = ""
 
+        owner = job["owner"]
+        if "keepalivehost" in job and job["keepalivehost"] is not None:
+            owner += " (%s)" % job["keepalivehost"]
+
         table.append((
             job["job_id"],
             job_state,
@@ -95,7 +99,7 @@ def render_job_list(t, jobs, args):
             machine_name,
             timestamp,
             str(job["keepalive"]),
-            job["owner"],
+            owner,
         ))
     return render_table(table)
 

--- a/tests/scripts/test_machine.py
+++ b/tests/scripts/test_machine.py
@@ -123,7 +123,7 @@ def test_show_machine(capsys):
         r"/ A \___/ . \___/" "\n"
         r"\___/   \___/" "\n"
         "\n"
-        "Key  Job ID  Num boards  Owner\n"
+        "Key  Job ID  Num boards  Owner (Host)\n"
         "A         0           1  me\n"
         "B         1           2  me\n"
     )

--- a/tests/scripts/test_ps.py
+++ b/tests/scripts/test_ps.py
@@ -56,6 +56,21 @@ def test_render_job_list(machine, owner):
             "allocated_machine_name": "a",
             "boards": [[[0, 0], "m00"]],
         },
+        # A ready, powered-on job with a keepalive host
+        {
+            "job_id": 1,
+            "owner": "me",
+            "start_time": epoch,
+            "keepalive": 60.0,
+            "machine": None,
+            "state": int(JobState.ready),
+            "power": True,
+            "args": [],
+            "kwargs": {},
+            "allocated_machine_name": "a",
+            "boards": [[[0, 0], "m00"]],
+            "keepalivehost": "1.2.3.4",
+        },
         # A ready, powered-off job
         {
             "job_id": 2,
@@ -130,8 +145,10 @@ def test_render_job_list(machine, owner):
 
     nt = collections.namedtuple("args", "machine,owner")
     assert render_job_list(t, jobs, nt(machine, owner)) == (
-        "ID  State  Power  Boards  Machine  Created at           Keepalive  Owner\n" +  # noqa
+        "ID  State  Power  Boards  Machine  Created at           Keepalive  Owner (Host)\n" +  # noqa
         (" 1  ready  on          1  a        01/01/1970 00:00:00  60.0       me\n"      # noqa
+         if not owner else "") +
+        (" 1  ready  on          1  a        01/01/1970 00:00:00  60.0       me (1.2.3.4)\n"  # noqa
          if not owner else "") +
         (" 2  ready  off         1  b        01/01/1970 00:00:00  60.0       me\n"      # noqa
          if not owner and not machine else "") +


### PR DESCRIPTION
Client side updates relating to https://github.com/SpiNNakerManchester/spalloc_server/issues/1

This makes the scripts report the host that is keeping a job alive in places that are relevant (and only where that information is available). The host is expected to be reported in usual IP address dotted-quad form.