### PR TITLE
Enable testing against our real Python 3 target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
-sudo: false
 language: python
 python:
         - 2.7
         - 3.4
         - 3.5
+        - 3.6
+dist: trusty
 cache: pip
 before_install:
         - pip install --upgrade pip setuptools wheel

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 # Test suite requirements
+-r requirements.txt
 pytest>=2.8
 pytest-cov
 pytest-timeout

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # requirements
-six>=1.8.0,
-appdirs,
-enum-compat,
-pytz,
+six>=1.8.0
+appdirs
+enum-compat
+pytz
 tzlocal

--- a/spalloc/protocol_client.py
+++ b/spalloc/protocol_client.py
@@ -7,6 +7,7 @@ from collections import deque
 from spalloc._utils import time_left, timed_out, make_timeout
 import errno
 import sys
+from six import raise_from
 
 
 class ProtocolError(Exception):
@@ -297,7 +298,7 @@ class ProtocolClient(object):
                 with self._notifications_lock:
                     self._notifications.append(obj)
         except (IOError, OSError) as e:
-            raise ProtocolError(str(e))
+            raise_from(ProtocolError(str(e)), e)
 
     def wait_for_notification(self, timeout=None):
         """Return the next notification to arrive.
@@ -339,7 +340,7 @@ class ProtocolClient(object):
         try:
             return self._recv_json(timeout)
         except (IOError, OSError) as e:  # pragma: no cover
-            raise ProtocolError(str(e))
+            raise_from(ProtocolError(str(e)), e)
 
     # The bindings of the Spalloc protocol methods themselves; simplifies use
     # from IDEs.


### PR DESCRIPTION
Also fixes a few silly errors in the requirements files.

_Does not depend on rest of SpiNNaker software stack being updated._