### PR TITLE
Make keepalive process

### DIFF
--- a/spalloc/_keepalive_process.py
+++ b/spalloc/_keepalive_process.py
@@ -25,40 +25,30 @@ class KeepAliveProcess(object):
         """Background keep-alive thread."""
         self._running.set()
         client = ProtocolClient(hostname, port)
-        print "Connect"
         client.connect(timeout)
 
         # Send the keepalive packet twice as often as required
         if keepalive is not None:
             keepalive /= 2.0
-        print "Wait", keepalive
         while not self._stop.wait(keepalive):
 
             # Keep trying to send the keep-alive packet, if this fails,
             # keep trying to reconnect until it succeeds.
-            print "Stop set", self._stop.is_set()
             while not self._stop.is_set():
                 try:
-                    print "Keepalive"
                     client.job_keepalive(job_id, timeout=timeout)
                     break
                 except (ProtocolTimeoutError, IOError, OSError):
-                    print "Error"
                     # Something went wrong, reconnect, after a delay which
                     # may be interrupted by the thread being stopped
 
                     # pylint: disable=protected-access
                     client._close()
-                    print "Wait", reconnect_delay
                     if not self._stop.wait(reconnect_delay):
-                        print "Reconnect"
                         try:
                             client.connect(timeout)
-                            print "Reconnected"
                         except (IOError, OSError):
-                            print "Reconnect Error"
                             client.close()
-        print "Stopped"
 
 
 if __name__ == "__main__":

--- a/spalloc/_keepalive_process.py
+++ b/spalloc/_keepalive_process.py
@@ -1,65 +1,90 @@
+""" A script for keeping Spalloc jobs alive, intended to only ever be run\
+    from the Spalloc client itself.
+"""
+
+
 from spalloc.protocol_client import ProtocolClient, ProtocolTimeoutError
 import sys
 import threading
 
 
-def _wait_for_exit(keepalive):
+def wait_for_exit(stop_event):
+    """ Listens to stdin for a line equal to 'exit' or end-of-file and then\
+        notifies the given event (that it is time to stop keeping the Spalloc\
+        job alive). 
+
+    :param stop_event: Used to notify another thread that is time to stop.
+    :type stop_event: threading.Event
+    """
     for line in sys.stdin:
         if line.strip() == "exit":
-            keepalive.stop()
+            break
+    stop_event.set()
 
 
-class KeepAliveProcess(object):
+def keep_job_alive(hostname, port, job_id, keepalive_period, timeout,
+               reconnect_delay, stop_event):
+    """ Keeps a Spalloc job alive. Run as a separate process to the main\
+        Spalloc client.
 
-    def __init__(self):
-        self._stop = threading.Event()
-        self._running = threading.Event()
+    :param hostname: The address of the Spalloc server.
+    :param port: The port of the Spalloc server.
+    :param job_id: The ID of the Spalloc job to keep alive.
+    :param keepalive_period: \
+        How long will the job live without a keep-alive message being sent.
+    :param timeout: The communication timeout.
+    :param reconnect_delay: \
+        The delay before reconnecting on communication failure.
+    :param stop_event: Used to notify this function that it is time to stop \
+        keeping the job alive.
+    :type stop_event: threading.Event
+    """
+    client = ProtocolClient(hostname, port)
+    client.connect(timeout)
 
-    def stop(self):
-        self._stop.set()
+    # Send the keepalive packet twice as often as required
+    if keepalive_period is not None:
+        keepalive_period /= 2.0
+    while not stop_event.wait(keepalive_period):
 
-    def wait_for_start(self):
-        self._running.wait()
+        # Keep trying to send the keep-alive packet, if this fails,
+        # keep trying to reconnect until it succeeds.
+        while not stop_event.is_set():
+            try:
+                client.job_keepalive(job_id, timeout=timeout)
+                break
+            except (ProtocolTimeoutError, IOError, OSError):
+                # Something went wrong, reconnect, after a delay which
+                # may be interrupted by the thread being stopped
 
-    def run(self, hostname, port, job_id, keepalive, timeout, reconnect_delay):
-        """Background keep-alive thread."""
-        self._running.set()
-        client = ProtocolClient(hostname, port)
-        client.connect(timeout)
-
-        # Send the keepalive packet twice as often as required
-        if keepalive is not None:
-            keepalive /= 2.0
-        while not self._stop.wait(keepalive):
-
-            # Keep trying to send the keep-alive packet, if this fails,
-            # keep trying to reconnect until it succeeds.
-            while not self._stop.is_set():
-                try:
-                    client.job_keepalive(job_id, timeout=timeout)
-                    break
-                except (ProtocolTimeoutError, IOError, OSError):
-                    # Something went wrong, reconnect, after a delay which
-                    # may be interrupted by the thread being stopped
-
-                    # pylint: disable=protected-access
-                    client._close()
-                    if not self._stop.wait(reconnect_delay):
-                        try:
-                            client.connect(timeout)
-                        except (IOError, OSError):
-                            client.close()
+                # pylint: disable=protected-access
+                client._close()
+                if not stop_event.wait(reconnect_delay):
+                    try:
+                        client.connect(timeout)
+                    except (IOError, OSError):
+                        client.close()
 
 
 if __name__ == "__main__":
+    if len(sys.argv) != 7:
+        sys.stderr.write(
+            "wrong # args: should be '" + sys.argv[0] + " hostname port "
+            "job_id keepalive_delay comms_timeout reconnect_delay'\n")
+        sys.exit(1)
     hostname = sys.argv[1]
     port = int(sys.argv[2])
     job_id = int(sys.argv[3])
     keepalive = float(sys.argv[4])
     timeout = float(sys.argv[5])
     reconnect_delay = float(sys.argv[6])
-    keep_alive = KeepAliveProcess()
-    exit_thread = threading.Thread(target=_wait_for_exit, args=(keep_alive,))
-    exit_thread.daemon = True
-    exit_thread.start()
-    keep_alive.run(hostname, port, job_id, keepalive, timeout, reconnect_delay)
+
+    # Set things up so that we can detect when to stop
+    stop_event = threading.Event()
+    stdin_watcher_thread = threading.Thread(
+        target=wait_for_exit, args=(stop_event,), daemon=True)
+    stdin_watcher_thread.start()
+
+    # Start keeping the job alive
+    keep_job_alive(hostname, port, job_id, keepalive, timeout,
+                   reconnect_delay, stop_event)

--- a/spalloc/_keepalive_process.py
+++ b/spalloc/_keepalive_process.py
@@ -1,0 +1,48 @@
+from spalloc.protocol_client import ProtocolClient, ProtocolTimeoutError
+import sys
+import threading
+
+stop = threading.Event()
+
+
+def wait_for_exit():
+    global stop
+    for line in sys.stdin:
+        if line.strip() == "exit":
+            stop.set()
+
+
+if __name__ == "__main__":
+    hostname = sys.argv[1]
+    port = int(sys.argv[2])
+    job_id = int(sys.argv[3])
+    keepalive = float(sys.argv[4])
+    timeout = float(sys.argv[5])
+    reconnect_delay = float(sys.argv[6])
+    exit_thread = threading.Thread(target=wait_for_exit)
+    exit_thread.daemon = True
+    exit_thread.start()
+
+    """Background keep-alive thread."""
+    client = ProtocolClient(hostname, port)
+    client.connect(timeout)
+
+    # Send the keepalive packet twice as often as required
+    if keepalive is not None:
+        keepalive /= 2.0
+    while not stop.wait(keepalive):
+
+        # Keep trying to send the keep-alive packet, if this fails,
+        # keep trying to reconnect until it succeeds.
+        while not stop.is_set():
+            try:
+                client.job_keepalive(job_id, timeout=timeout)
+                break
+            except (ProtocolTimeoutError, IOError, OSError):
+                # Something went wrong, reconnect, after a delay which
+                # may be interrupted by the thread being stopped
+
+                # pylint: disable=protected-access
+                client._close()
+                if not stop.wait(reconnect_delay):
+                    client.connect(timeout)

--- a/spalloc/_keepalive_process.py
+++ b/spalloc/_keepalive_process.py
@@ -2,53 +2,63 @@ from spalloc.protocol_client import ProtocolClient, ProtocolTimeoutError
 import sys
 import threading
 
-stop = threading.Event()
 
-
-def wait_for_exit():
-    global stop
+def _wait_for_exit(keepalive):
     for line in sys.stdin:
         if line.strip() == "exit":
-            stop.set()
+            keepalive.stop()
 
 
-def main(hostname, port, job_id, keepalive, timeout, reconnect_delay):
-    """Background keep-alive thread."""
-    client = ProtocolClient(hostname, port)
-    print "Connect"
-    client.connect(timeout)
+class KeepAliveProcess(object):
 
-    # Send the keepalive packet twice as often as required
-    if keepalive is not None:
-        keepalive /= 2.0
-    print "Wait", keepalive
-    while not stop.wait(keepalive):
+    def __init__(self):
+        self._stop = threading.Event()
+        self._running = threading.Event()
 
-        # Keep trying to send the keep-alive packet, if this fails,
-        # keep trying to reconnect until it succeeds.
-        print "Stop set", stop.is_set()
-        while not stop.is_set():
-            try:
-                print "Keepalive"
-                client.job_keepalive(job_id, timeout=timeout)
-                break
-            except (ProtocolTimeoutError, IOError, OSError):
-                print "Error"
-                # Something went wrong, reconnect, after a delay which
-                # may be interrupted by the thread being stopped
+    def stop(self):
+        self._stop.set()
 
-                # pylint: disable=protected-access
-                client._close()
-                print "Wait", reconnect_delay
-                if not stop.wait(reconnect_delay):
-                    print "Reconnect"
-                    try:
-                        client.connect(timeout)
-                        print "Reconnected"
-                    except (IOError, OSError):
-                        print "Reconnect Error"
-                        client.close()
-    print "Stopped"
+    def wait_for_start(self):
+        self._running.wait()
+
+    def run(self, hostname, port, job_id, keepalive, timeout, reconnect_delay):
+        """Background keep-alive thread."""
+        self._running.set()
+        client = ProtocolClient(hostname, port)
+        print "Connect"
+        client.connect(timeout)
+
+        # Send the keepalive packet twice as often as required
+        if keepalive is not None:
+            keepalive /= 2.0
+        print "Wait", keepalive
+        while not self._stop.wait(keepalive):
+
+            # Keep trying to send the keep-alive packet, if this fails,
+            # keep trying to reconnect until it succeeds.
+            print "Stop set", self._stop.is_set()
+            while not self._stop.is_set():
+                try:
+                    print "Keepalive"
+                    client.job_keepalive(job_id, timeout=timeout)
+                    break
+                except (ProtocolTimeoutError, IOError, OSError):
+                    print "Error"
+                    # Something went wrong, reconnect, after a delay which
+                    # may be interrupted by the thread being stopped
+
+                    # pylint: disable=protected-access
+                    client._close()
+                    print "Wait", reconnect_delay
+                    if not self._stop.wait(reconnect_delay):
+                        print "Reconnect"
+                        try:
+                            client.connect(timeout)
+                            print "Reconnected"
+                        except (IOError, OSError):
+                            print "Reconnect Error"
+                            client.close()
+        print "Stopped"
 
 
 if __name__ == "__main__":
@@ -58,7 +68,8 @@ if __name__ == "__main__":
     keepalive = float(sys.argv[4])
     timeout = float(sys.argv[5])
     reconnect_delay = float(sys.argv[6])
-    exit_thread = threading.Thread(target=wait_for_exit)
+    keep_alive = KeepAliveProcess()
+    exit_thread = threading.Thread(target=_wait_for_exit, args=(keep_alive,))
     exit_thread.daemon = True
     exit_thread.start()
-    main(hostname, port, job_id, keepalive, timeout, reconnect_delay)
+    keep_alive.run(hostname, port, job_id, keepalive, timeout, reconnect_delay)

--- a/spalloc/_keepalive_process.py
+++ b/spalloc/_keepalive_process.py
@@ -11,7 +11,7 @@ import threading
 def wait_for_exit(stop_event):
     """ Listens to stdin for a line equal to 'exit' or end-of-file and then\
         notifies the given event (that it is time to stop keeping the Spalloc\
-        job alive). 
+        job alive).
 
     :param stop_event: Used to notify another thread that is time to stop.
     :type stop_event: threading.Event
@@ -23,7 +23,7 @@ def wait_for_exit(stop_event):
 
 
 def keep_job_alive(hostname, port, job_id, keepalive_period, timeout,
-               reconnect_delay, stop_event):
+                   reconnect_delay, stop_event):
     """ Keeps a Spalloc job alive. Run as a separate process to the main\
         Spalloc client.
 

--- a/spalloc/_keepalive_process.py
+++ b/spalloc/_keepalive_process.py
@@ -12,17 +12,7 @@ def wait_for_exit():
             stop.set()
 
 
-if __name__ == "__main__":
-    hostname = sys.argv[1]
-    port = int(sys.argv[2])
-    job_id = int(sys.argv[3])
-    keepalive = float(sys.argv[4])
-    timeout = float(sys.argv[5])
-    reconnect_delay = float(sys.argv[6])
-    exit_thread = threading.Thread(target=wait_for_exit)
-    exit_thread.daemon = True
-    exit_thread.start()
-
+def main(hostname, port, job_id, keepalive, timeout, reconnect_delay):
     """Background keep-alive thread."""
     client = ProtocolClient(hostname, port)
     client.connect(timeout)
@@ -45,4 +35,20 @@ if __name__ == "__main__":
                 # pylint: disable=protected-access
                 client._close()
                 if not stop.wait(reconnect_delay):
-                    client.connect(timeout)
+                    try:
+                        client.connect(timeout)
+                    except (IOError, OSError):
+                        client.close()
+
+
+if __name__ == "__main__":
+    hostname = sys.argv[1]
+    port = int(sys.argv[2])
+    job_id = int(sys.argv[3])
+    keepalive = float(sys.argv[4])
+    timeout = float(sys.argv[5])
+    reconnect_delay = float(sys.argv[6])
+    exit_thread = threading.Thread(target=wait_for_exit)
+    exit_thread.daemon = True
+    exit_thread.start()
+    main(hostname, port, job_id, keepalive, timeout, reconnect_delay)

--- a/spalloc/_keepalive_process.py
+++ b/spalloc/_keepalive_process.py
@@ -15,30 +15,40 @@ def wait_for_exit():
 def main(hostname, port, job_id, keepalive, timeout, reconnect_delay):
     """Background keep-alive thread."""
     client = ProtocolClient(hostname, port)
+    print "Connect"
     client.connect(timeout)
 
     # Send the keepalive packet twice as often as required
     if keepalive is not None:
         keepalive /= 2.0
+    print "Wait", keepalive
     while not stop.wait(keepalive):
 
         # Keep trying to send the keep-alive packet, if this fails,
         # keep trying to reconnect until it succeeds.
+        print "Stop set", stop.is_set()
         while not stop.is_set():
             try:
+                print "Keepalive"
                 client.job_keepalive(job_id, timeout=timeout)
                 break
             except (ProtocolTimeoutError, IOError, OSError):
+                print "Error"
                 # Something went wrong, reconnect, after a delay which
                 # may be interrupted by the thread being stopped
 
                 # pylint: disable=protected-access
                 client._close()
+                print "Wait", reconnect_delay
                 if not stop.wait(reconnect_delay):
+                    print "Reconnect"
                     try:
                         client.connect(timeout)
+                        print "Reconnected"
                     except (IOError, OSError):
+                        print "Reconnect Error"
                         client.close()
+    print "Stopped"
 
 
 if __name__ == "__main__":

--- a/spalloc/job.py
+++ b/spalloc/job.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 import logging
 import subprocess
 import time
+import sys
 
 from .protocol_client import ProtocolClient, ProtocolTimeoutError
 from .config import read_config, SEARCH_PATH
@@ -298,8 +299,8 @@ class Job(object):
 
         # Set-up and start background keepalive thread
         self._keepalive_process = subprocess.Popen(map(str, [
-                "python", "-m", "spalloc._keepalive_process", hostname, port,
-                self.id, self._keepalive, self._timeout,
+                sys.executable, "-m", "spalloc._keepalive_process", hostname,
+                port, self.id, self._keepalive, self._timeout,
                 self._reconnect_delay]), stdin=subprocess.PIPE)
 
     def __enter__(self):

--- a/spalloc/job.py
+++ b/spalloc/job.py
@@ -387,7 +387,7 @@ class Job(object):
         """
         # Stop background thread
         if self._keepalive_process.poll() is None:
-            self._keepalive_process.communicate(input="exit\n")
+            self._keepalive_process.communicate(input="exit\n".encode("ascii"))
             self._keepalive_process.wait()
 
         # Disconnect

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -4,15 +4,14 @@ from mock import Mock
 
 import time
 
-from spalloc import Job, JobState, JobDestroyedError, ProtocolTimeoutError,\
-    _keepalive_process
+from spalloc import Job, JobState, JobDestroyedError, ProtocolTimeoutError
 
+from spalloc._keepalive_process import KeepAliveProcess
 from spalloc.job import \
     _JobStateTuple, _JobMachineInfoTuple, \
     VERSION_RANGE_START, VERSION_RANGE_STOP, \
     StateChangeTimeoutError
 
-import spalloc._keepalive_process as keepalive
 from threading import Thread
 
 GOOD_VERSION = ".".join(map(str, VERSION_RANGE_START))
@@ -29,7 +28,8 @@ def client(monkeypatch):
     import spalloc.job
     monkeypatch.setattr(spalloc.job, "ProtocolClient",
                         Mock(return_value=client))
-    monkeypatch.setattr(_keepalive_process, "ProtocolClient",
+    import spalloc._keepalive_process
+    monkeypatch.setattr(spalloc._keepalive_process, "ProtocolClient",
                         Mock(return_value=client))
     return client
 
@@ -166,11 +166,13 @@ class TestKeepalive(object):
     def test_normal_operation(self, client, no_config_files):
         # Make sure that the keepalive is sent out at the correct interval by
         # the background thread (and make sure this thread is daemonic
-        j = Thread(target=keepalive.main, args=(
+        keepalive = KeepAliveProcess()
+        j = Thread(target=keepalive.run, args=(
             "localhost", 12345, 1, 0.2, 0.1, 0.1))
         j.start()
+        keepalive.wait_for_start()
         time.sleep(0.5)
-        keepalive.stop.set()
+        keepalive.stop()
 
         assert 4 <= len(client.job_keepalive.mock_calls) <= 6
 
@@ -180,11 +182,13 @@ class TestKeepalive(object):
             IOError(), IOError(), None, None, None, None]
         client.connect.side_effect = [
             None, IOError(), None, None, None, None]
-        j = Thread(target=keepalive.main, args=(
+        keepalive = KeepAliveProcess()
+        j = Thread(target=keepalive.run, args=(
             "localhost", 12345, 1, 0.2, 0.1, 0.2))
         j.start()
-        time.sleep(0.75)
-        keepalive.stop.set()
+        keepalive.wait_for_start()
+        time.sleep(0.55)
+        keepalive.stop()
 
         # Should have attempted a reconnect after a 0.1 + 0.2 second delay then
         # started sending keepalives as usual every 0.1 sec

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -183,7 +183,7 @@ class TestKeepalive(object):
         j = Thread(target=keepalive.main, args=(
             "localhost", 12345, 1, 0.2, 0.1, 0.2))
         j.start()
-        time.sleep(0.55)
+        time.sleep(0.75)
         keepalive.stop.set()
 
         # Should have attempted a reconnect after a 0.1 + 0.2 second delay then

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -170,7 +170,7 @@ class TestKeepalive(object):
         j = Thread(target=keep_job_alive, args=(
             "localhost", 12345, 1, 0.2, 0.1, 0.1, event))
         j.start()
-        time.sleep(1)
+        time.sleep(0.55)
         event.set()
 
         assert 4 <= len(client.job_keepalive.mock_calls) <= 6
@@ -184,6 +184,7 @@ class TestKeepalive(object):
         event = Event()
         j = Thread(target=keep_job_alive, args=(
             "localhost", 12345, 1, 0.2, 0.1, 0.2, event))
+        j.start()
         time.sleep(0.55)
         event.set()
 


### PR DESCRIPTION
This moves the spalloc keepalive thread into a process.  Note that this doesn't use multiprocessing.process as this doesn't work well across platforms.  Instead the code is written into a separate Python file which is executed as a process independently.

Tests have been updated to reflect this.