### PR TITLE
Jenkins

### DIFF
--- a/spalloc/_keepalive_process.py
+++ b/spalloc/_keepalive_process.py
@@ -1,6 +1,7 @@
 """ A script for keeping Spalloc jobs alive, intended to only ever be run\
     from the Spalloc client itself.
 """
+from __future__ import print_function
 import sys
 import threading
 from spalloc.protocol_client import ProtocolClient, ProtocolTimeoutError
@@ -65,6 +66,8 @@ def keep_job_alive(hostname, port, job_id, keepalive_period, timeout,
 
 
 if __name__ == "__main__":
+    print("KEEPALIVE")
+    sys.stdout.flush()
     if len(sys.argv) != 7:
         sys.stderr.write(
             "wrong # args: should be '" + sys.argv[0] + " hostname port "

--- a/spalloc/job.py
+++ b/spalloc/job.py
@@ -304,6 +304,8 @@ class Job(object):
                 self._reconnect_delay]), stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         first_line = self._keepalive_process.stdout.readline().strip()
+        if first_line.startswith("pydev debugger"):
+            first_line = self._keepalive_process.stdout.readline().strip()
         if first_line != "KEEPALIVE":
             raise Exception("Keepalive process wrote odd line: {}".format(
                 first_line))

--- a/spalloc/job.py
+++ b/spalloc/job.py
@@ -304,9 +304,11 @@ class Job(object):
                 self._reconnect_delay]), stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         first_line = self._keepalive_process.stdout.readline().strip()
-        if first_line.startswith("pydev debugger"):
+        if first_line.startswith(b"pydev debugger"):
             first_line = self._keepalive_process.stdout.readline().strip()
-        if first_line != "KEEPALIVE":
+            if len(first_line) == 0:
+                first_line = self._keepalive_process.stdout.readline().strip()
+        if first_line != b"KEEPALIVE":
             raise Exception("Keepalive process wrote odd line: {}".format(
                 first_line))
 


### PR DESCRIPTION
This came up during some tests, where launching the thread runs the system out of RAM (because Linux forks are just the worst idea for launching new processes, but nothing else exists in Linux).  I think the issue might be that after the process is launched, the fork creates a "copy on write" area of memory, so if you don't wait for the process to do the exec, the first process will likely write all over the place and cause the memory to attempt to copy, but run out.  So this fix makes the parent process wait until it is sure that the child process has done the exec before continuing.  Seems to work...