### PR TITLE
Corrections to timestamp rendering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,4 @@
 six>=1.8.0
 appdirs
 enum-compat
-pytz
-tzlocal
 future

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,6 @@ setup(
     install_requires=["six>=1.8.0",
                       "appdirs",
                       "enum-compat",
-                      "pytz",
-                      "tzlocal",
                       "future"],
     # Scripts
     entry_points={

--- a/spalloc/_utils.py
+++ b/spalloc/_utils.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from datetime import datetime
 import time
 
 
@@ -38,3 +39,10 @@ def make_timeout(delay_seconds):
     if delay_seconds is None:
         return None
     return time.time() + delay_seconds
+
+
+def render_timestamp(timestamp):
+    """ Convert a timestamp (Unix seconds) into a local human-readable\
+        timestamp string.
+    """
+    return datetime.fromtimestamp(timestamp).strftime("%d/%m/%Y %H:%M:%S")

--- a/spalloc/scripts/job.py
+++ b/spalloc/scripts/job.py
@@ -76,14 +76,12 @@ which optionally accepts a human-readable explanation::
 """
 import argparse
 from collections import OrderedDict
-import datetime
 import sys
-from pytz import utc
-from tzlocal import get_localzone
 from six import iteritems
 from spalloc import __version__, JobState
 from spalloc.term import (
     Terminal, render_definitions, render_boards, DEFAULT_BOARD_EDGES)
+from spalloc._utils import render_timestamp
 from .support import Terminate, Script
 
 
@@ -131,10 +129,7 @@ def show_job_info(t, client, timeout, job_id):
         info["Owner"] = job["owner"]
         info["State"] = _state_name(job)
         if job["start_time"] is not None:
-            utc_timestamp = datetime.datetime.fromtimestamp(
-                job["start_time"], utc)
-            local_timestamp = utc_timestamp.astimezone(get_localzone())
-            info["Start time"] = local_timestamp.strftime('%d/%m/%Y %H:%M:%S')
+            info["Start time"] = render_timestamp(job["start_time"])
         info["Keepalive"] = job["keepalive"]
         if "keepalivehost" in job and job["keepalivehost"] is not None:
             info["Owner host"] = job["keepalivehost"]

--- a/spalloc/scripts/ps.py
+++ b/spalloc/scripts/ps.py
@@ -26,12 +26,10 @@ This list may be filtered by owner or machine with the ``--owner`` and
 ``--machine`` arguments.
 """
 import argparse
-import datetime
 import sys
-from pytz import utc
-from tzlocal import get_localzone
 from spalloc import __version__, JobState
 from spalloc.term import Terminal, render_table
+from spalloc._utils import render_timestamp
 from .support import Script
 
 
@@ -90,10 +88,7 @@ def render_job_list(t, jobs, args):
         num_boards = "" if job["boards"] is None else len(job["boards"])
 
         # Format start time
-        utc_timestamp = datetime.datetime.fromtimestamp(
-            job["start_time"], utc)
-        local_timestamp = utc_timestamp.astimezone(get_localzone())
-        timestamp = local_timestamp.strftime('%d/%m/%Y %H:%M:%S')
+        timestamp = render_timestamp(job["start_time"])
 
         if job["allocated_machine_name"] is not None:
             machine_name = job["allocated_machine_name"]


### PR DESCRIPTION
Make the timestamp rendering code work given changes to upstream packages. This might change the timestamps to be rendered using the local timezone. This shouldn't matter too much to us.

fixes #49