### PR TITLE
Python3.11 with no Rig

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 The University of Manchester
+# Copyright (c) 2016-2022 The University of Manchester
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,4 +21,3 @@ pytest-cov
 pytest-timeout
 flake8
 mock
-rig

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     },
     # Booting directly needs rig; not recommended! Use SpiNNMan instead, as
     # that has an up-to-date boot image pre-built
+    # Note rig does not work with python 3.11 and there are NO plans to fix it
     extras_require={
         'boot': [
             'rig',


### PR DESCRIPTION
Extends https://github.com/SpiNNakerManchester/spalloc/pull/65
to also test Python 3.11 wihich we know breaks rig.