### PR TITLE
Remove references to rig

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -152,9 +152,9 @@ pygments_style = 'sphinx'
 # keep_warnings = False
 
 # Search Python docs for extra definitions.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
-                       'rig': ('https://rig.readthedocs.org/en/stable/', None)
-                       }
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None)
+}
 
 # -- linkcode GitHub link generator ---------------------------------------
 

--- a/spalloc_client/scripts/alloc.py
+++ b/spalloc_client/scripts/alloc.py
@@ -30,11 +30,7 @@ powered on.
 
 .. note::
 
-    By default, allocated machines are powered on but not booted. If
-    `Rig <https://github.com/project-rig/rig>`__
-    is installed, ``spalloc`` provides a ``--boot`` option which also boots
-    the allocated machine once it has been powered on. This dependency can be
-    installed using the ``[boot]`` option at install time for spalloc.
+    Allocated machines are powered on but not booted.
 
 .. image:: _static/spalloc.gif
     :alt: Animated GIF showing the typical execution of a spalloc call.
@@ -120,11 +116,6 @@ from spalloc_client import (
     config, Job, JobState, __version__, ProtocolError, ProtocolTimeoutError,
     SpallocServerException)
 from spalloc_client.term import Terminal, render_definitions
-# Rig is used to implement the optional '--boot' facility.
-try:
-    from rig.machine_control import MachineController
-except ImportError:  # pragma: no cover
-    MachineController = None
 
 arguments = None
 t = None
@@ -330,9 +321,6 @@ def parse_argv(argv):
     parser.add_argument("--no-destroy", "-D", action="store_true",
                         default=False,
                         help="do not destroy the job on exit")
-    if MachineController:
-        parser.add_argument("--boot", "-B", action="store_true", default=False,
-                            help="boot the machine once powered on")
 
     allocation_args = parser.add_argument_group(
         "allocation requirement arguments")
@@ -441,12 +429,6 @@ def run_job(job_args, job_kwargs, ip_file_filename):
 
         # Machine is now ready
         write_ips_to_csv(job.connections, ip_file_filename)
-
-        # Boot the machine if required
-        if MachineController and arguments.boot:
-            update("Job {}: Booting...", t.yellow, job.id)
-            mc = MachineController(job.hostname)
-            mc.boot(job.width, job.height)
 
         update("Job {}: Ready!", t.green, job.id)
 

--- a/tests/scripts/test_alloc.py
+++ b/tests/scripts/test_alloc.py
@@ -77,14 +77,6 @@ def mock_working_job(monkeypatch):
     return job
 
 
-@pytest.fixture
-def mock_mc(monkeypatch):
-    mc = Mock(return_value=Mock())
-    import spalloc_client.scripts.alloc
-    monkeypatch.setattr(spalloc_client.scripts.alloc, "MachineController", mc)
-    return mc
-
-
 def test_write_ips_to_file_empty(filename):
     write_ips_to_csv({}, filename)
 
@@ -303,7 +295,7 @@ def test_timeout_args(basic_config_file, mock_job, basic_job_kwargs):
 
 
 def test_default_info(capsys, basic_config_file, mock_working_job, mock_input,
-                      mock_mc, no_colour):
+                      no_colour):
     assert main([]) == 0
 
     out, err = capsys.readouterr()

--- a/tests/scripts/test_alloc.py
+++ b/tests/scripts/test_alloc.py
@@ -85,13 +85,6 @@ def mock_mc(monkeypatch):
     return mc
 
 
-@pytest.fixture
-def no_rig(monkeypatch):
-    import spalloc_client.scripts.alloc
-    monkeypatch.setattr(
-        spalloc_client.scripts.alloc, "MachineController", None)
-
-
 def test_write_ips_to_file_empty(filename):
     write_ips_to_csv({}, filename)
 
@@ -309,27 +302,9 @@ def test_timeout_args(basic_config_file, mock_job, basic_job_kwargs):
     mock_job.assert_called_once_with(**basic_job_kwargs)
 
 
-@pytest.mark.parametrize("args,boot", [("--boot", True), ("", False)])
-def test_boot_args(basic_config_file, mock_working_job, mock_input,
-                   args, boot, mock_mc):
-    assert main(args.split()) == 0
-
-    if boot:
-        mock_mc.assert_called_once_with("foobar")
-        mock_mc().boot.assert_called_once_with(8, 8)
-    else:
-        assert len(mock_mc.mock_calls) == 0
-
-
-def test_no_boot_arg_when_no_rig(basic_config_file, mock_job, no_rig):
-    with pytest.raises(SystemExit):
-        main("--boot".split())
-
-
-@pytest.mark.parametrize("args,boot", [("--boot", True), ("", False)])
 def test_default_info(capsys, basic_config_file, mock_working_job, mock_input,
-                      args, boot, mock_mc, no_colour):
-    assert main(args.split()) == 0
+                      mock_mc, no_colour):
+    assert main([]) == 0
 
     out, err = capsys.readouterr()
 
@@ -339,8 +314,6 @@ def test_default_info(capsys, basic_config_file, mock_working_job, mock_input,
     # Should have printed no debug output
     expected = ("Job 123: Waiting in queue...\n"
                 "Job 123: Waiting for power on...\n")
-    if boot:
-        expected += "Job 123: Booting...\n"
     expected += "Job 123: Ready!\n"
 
     assert err == expected


### PR DESCRIPTION
Removes unwanted code references to Rig. It was just for booting boards, and so it used an old (and likely subtly buggy) version of SCAMP. The option to install it to support booting was already gone during the rewrite of how project installation configurations are done.

The sole remaining reference is as part of documentation where it is a thing that _could_ boot a SpiNNaker allocation. That's OK. 

This fixes #46